### PR TITLE
fixed duplicate startup worker bug

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -3,8 +3,7 @@ var _ = require('lodash');
 module.exports = function (context, config) {
     var cluster = context.cluster;
     var logger = context.logger;
-    var start_workers = config.start_workers ? config.start_workers : true;
-
+    var start_workers = config.start_workers ?  true : config.start_workers;
     var plugin = context.master_plugin;
 
     if (plugin) plugin.pre();


### PR DESCRIPTION
accidently had the values of the ternary statement backwards, we are expecting a falsey value so had to switch the order
