### PR TITLE
Upgrading ES lib and explicitly using bluebird to support ES 5

### DIFF
--- a/lib/connectors/elasticsearch.js
+++ b/lib/connectors/elasticsearch.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Promise = require('bluebird');
 var Agent = require('./elastic_helpers');
 
 function logWrapper(logger) {
@@ -29,6 +30,9 @@ function create(customConfig, logger) {
     logger.info("Using elasticsearch hosts: " + customConfig.host);
 
     customConfig.connectionClass = Agent;
+    customConfig.defer = function () {
+        return Promise.defer();
+    }
     var client = new elasticsearch.Client(customConfig);
 
     return {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bunyan": "^1.3.4",
     "bunyan-elasticsearch": "0.0.1",
     "convict": "^1.0.1",
-    "elasticsearch": "^9.0.0",
+    "elasticsearch": "^12.0.0",
     "express": "^4.12.3",
     "js-yaml": "^3.4.2",
     "lodash": "~2.2.1",


### PR DESCRIPTION
The following changes were needed to support ES 5.0:

* Upgrade the ES js client to the current version `^12.0.0`
* Version 10 of the ES js client switched to native promises
which required that we explicitly defer to Bluebird to
maintain compatibility with our existing code base.

refs #68